### PR TITLE
Cleanup .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
 *.swp
 *.pyc
-people.txt
-bin/
-include/
-lib/
-pip-selfcheck.json
 *.lock
 target/
 *.bk


### PR DESCRIPTION
There were traces of ancient times when we used python to implement the
API.  This is all gone now, so no need to ignore it anymore.