### PR TITLE
Update rust to 1.18.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 MAINTAINER Danilo Bargen <mail@dbrgn.ch>
 
-ENV RUST_VERSION=1.9.0
+ENV RUST_VERSION=1.18.0
 
 # Build base system
 RUN apt-get update && \


### PR DESCRIPTION
The latest build of the docker image failed: https://quay.io/repository/coredump/status?tab=info probably because the used Rust version is too old.