### PR TITLE
Add people_in_cyberspace sensor endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ You can access the database with the `redis-cli` tool:
 We currently store data in the following redis keys:
 
 - people_now_present (integer)
+- people_in_cyberspace (integer)
 - raspi_temperature (float)
 - room_temperature (float)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,15 @@ fn main() {
             },
             "people_now_present".into(),
         )
+        .add_sensor(
+            PeopleNowPresentSensorTemplate {
+                location: Some("Cyberspace".into()),
+                name: None,
+                description: Some("Our virtual hackerspace meeting through Jitsi (because of COVID)".into()),
+                names: None,
+            },
+            "people_in_cyberspace".into(),
+        )
         .build()
         .expect("Could not build server");
 


### PR DESCRIPTION
Right now the opening status only considers the first entry in the people present sensor list, so only the physical presence is considered.

Is this good, or should we sum up all locations for the opening status? (Should Coredump be "open" even if nobody is there physically?)