### PR TITLE
Remove wrong 'readme' metadata field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ authors = [
     "Stefan Schindler <stefan@estada.ch>",
 ]
 repository = "https://github.com/coredump-ch/status"
-readme = "./README.rst"
 keywords = ["json", "spaceapi"]
 edition = "2018"
 


### PR DESCRIPTION
Readme.rst does not exist and cargo will use README.md by default if it
exists.